### PR TITLE
Fix emoji tooltips on 4k displays / different OS

### DIFF
--- a/app/components/RateJokeForm.tsx
+++ b/app/components/RateJokeForm.tsx
@@ -101,8 +101,10 @@ const JokeRatingFormGroup: React.FC<JokeRatingFormGroupProps> = ({
           before:content-[attr(data-count)]
 
           after:absolute
-          after:-inset-x-1/2
           after:bottom-10
+          after:left-1/2
+          after:-translate-x-1/2
+          after:whitespace-nowrap
           after:rounded
           after:bg-primary-500
           after:text-center
@@ -110,7 +112,8 @@ const JokeRatingFormGroup: React.FC<JokeRatingFormGroupProps> = ({
 
           hover:scale-125
 
-          hover:after:p-1
+          hover:after:px-2
+          hover:after:py-1
           hover:after:content-[attr(data-title)]
 
           peer-checked:before:rounded-full


### PR DESCRIPTION
@justinwaite mentioned the tooltips looked weird for him. The tooltip was being positioned -50% to the left and right, which was using the emoji's size, possibly resulting in different experience on different displays or operating systems.

According to [this StackOverflow answer](https://stackoverflow.com/a/71034345/651595) `transform: translateX(-50%)` on the pseudo element will use its own size instead of its parent's, resulting in a centered element in combination with `left: 50%`.

![image](https://user-images.githubusercontent.com/1333274/183711305-a4515c9f-2965-416c-bb55-ddca400f9b53.png)
